### PR TITLE
fix: use hash route

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,6 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import { BrowserRouter } from "react-router-dom";
+import { HashRouter } from "react-router-dom";
 import "./index.css";
 import App from "./App.tsx";
 
@@ -10,8 +10,8 @@ if (!root) throw new Error("Failed to find the root element");
 
 createRoot(root).render(
 	<StrictMode>
-		<BrowserRouter>
+		<HashRouter>
 			<App />
-		</BrowserRouter>
+		</HashRouter>
 	</StrictMode>,
 );


### PR DESCRIPTION
hash routeを使って、リロード時に404になる問題を修正

パスは
http://localhost:3000/introduction
↓
http://localhost:3000/#/introduction

になる