### PR TITLE
fix(a11y): clean up redundant image alt text

### DIFF
--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -18,7 +18,7 @@ export default function Header() {
             <Link to="/" className="flex items-center gap-2">
               <img
                 src="/logo.png"
-                alt="株式会社テックリード"
+                alt=""
                 className="h-8 w-8 object-contain translate-y-0.5"
               />
               <span className="text-xl font-bold text-gray-900">


### PR DESCRIPTION
## 作業内容
ヘッダーロゴのaltを空文字にしました。

### a11y スコア
| 変更後 | 変更前 |
| --- | --- |
| <img width="125" height="141" alt="株式会社テックリード" src="https://github.com/user-attachments/assets/63a9427c-ac78-46fc-b567-f78c84590f12" /> | <img width="125" height="160" alt="techlead-it_com" src="https://github.com/user-attachments/assets/23266bd5-4d50-495a-bc70-a7d54ac25266" /> |


## 変更理由
alt と同様のテキストが隣接する場合、スクリーンリーダーの重複読み上げを防ぐために alt は空文字が推奨されています。
https://dequeuniversity.com/rules/axe/4.10/image-redundant-alt?lang=ja

