### PR TITLE
fix(a11y): adjust labe bg-color to meet contrast ratio requirements

### DIFF
--- a/web/src/components/sections/ProjectsSection.tsx
+++ b/web/src/components/sections/ProjectsSection.tsx
@@ -16,7 +16,7 @@ export default function ProjectsSection({ background }: SectionProps) {
               {project.category.map((cat) => (
                 <span
                   key={cat}
-                  className="inline-block px-3 py-1 text-xs font-semibold text-blue-600 bg-blue-100 rounded-full"
+                  className="inline-block px-3 py-1 text-xs font-semibold text-blue-600 bg-blue-50 rounded-full"
                 >
                   {cat}
                 </span>


### PR DESCRIPTION
## 作業内容
実績紹介セクション｜ラベルとテキストの色コントラスト比のa11y対応を行いました。
デザインに触れてしまう箇所なので、ご要望あればご指摘お願いします。

### 変更箇所
| 変更後 | 変更前 |
| --- | --- |
| <img width="470" height="250" alt="株式会社テックリード" src="https://github.com/user-attachments/assets/8f66edb1-5fa0-4241-90da-b3a8bc5942d9" /> |  <img width="470" height="240" alt="株式会社テックリード" src="https://github.com/user-attachments/assets/ebe5b3f6-2bc7-45a5-82a8-d7140880bb20" /> |



### a11y スコア
| 変更後 | 変更前 |
| --- | --- |
| <img width="125" height="136" alt="Cursor_と_株式会社テックリード" src="https://github.com/user-attachments/assets/a0a1d1c4-7be4-4f6b-ba82-23e57f2fb34e" /> | <img width="125" height="160" alt="techlead-it_com" src="https://github.com/user-attachments/assets/23266bd5-4d50-495a-bc70-a7d54ac25266" /> |

※ #15 と合わせて、スコア 100 になります。

## 変更理由
ユーザーに読ませたい「要素は最低限の色のコントラスト比のしきい値を満たす必要があります」。
https://dequeuniversity.com/rules/axe/4.10/color-contrast?lang=ja

