### PR TITLE
chore: dependabotにcooldownを設定しminimumReleaseAgeと整合させる

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -17,6 +17,8 @@ updates:
       interval: daily
       time: "07:00"
       timezone: "Asia/Tokyo"
+    cooldown:
+      default-days: 1
     groups:
       all:
         patterns:


### PR DESCRIPTION
## Summary
- PR #66 のCI失敗（`pnpm install --frozen-lockfile` 失敗）の根本原因は、`pnpm-workspace.yaml` の `minimumReleaseAge: 1400`（約23.3時間）により、公開直後のバージョンがlockfileに解決されない一方、Dependabotはそのガードを考慮せずpackage.jsonだけを最新版に更新するため、manifestとlockfileが不整合になる点だった
- `cooldown.default-days: 1` を追加し、Dependabotが提案するバージョンの公開からの経過日数をpnpmの`minimumReleaseAge`と概ね揃える。これにより同種の更新提案を抑制し、再発を防ぐ

## Test plan
- [x] `.github/dependabot.yaml` のみの変更でCIワークフローのpathトリガーに含まれないため、CIは実行されない想定
- [ ] 次回のDependabot daily run (07:00 JST) 以降、提案される更新が`minimumReleaseAge`を満たすバージョンになっていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)