### PR TITLE
✨ feat: 業界・文脈別の会社紹介資料スライドの一覧と自動収集

### DIFF
--- a/web/plugins/vite-plugin-slides.ts
+++ b/web/plugins/vite-plugin-slides.ts
@@ -1,0 +1,61 @@
+import fs from "node:fs";
+import path from "node:path";
+import type { Plugin } from "vite-plus";
+import { parseSlideEntry } from "../src/data/slideParser";
+
+const VIRTUAL_ID = "virtual:slides";
+const RESOLVED_ID = `\0${VIRTUAL_ID}`;
+const SLIDES_DIR = path.resolve(import.meta.dirname, "../public/slides");
+
+/**
+ * public/slides/*.html を走査し、各HTMLの head メタから Slide 一覧を構築して
+ * `export const slides = [...]` のモジュールソースを生成する。
+ */
+const buildSlidesModule = (): string => {
+  const htmlFiles = fs.existsSync(SLIDES_DIR)
+    ? fs.readdirSync(SLIDES_DIR).filter((file) => file.endsWith(".html"))
+    : [];
+  // ファイル名昇順で決定的な順序にする（走査順は環境依存のため）
+  const entries = htmlFiles.toSorted().map((file) => {
+    const id = file.slice(0, -".html".length);
+    const html = fs.readFileSync(path.join(SLIDES_DIR, file), "utf-8");
+    return parseSlideEntry(id, html);
+  });
+  return `export const slides = ${JSON.stringify(entries)};`;
+};
+
+/**
+ * web/public/slides/*.html を置くだけで会社紹介資料の一覧に自動反映する。
+ * `virtual:slides` として Slide[] を供給する。
+ */
+export function vitePluginSlides(): Plugin {
+  return {
+    name: "vite-plugin-slides",
+
+    resolveId(id) {
+      return VIRTUAL_ID === id ? RESOLVED_ID : undefined;
+    },
+
+    load(id) {
+      return RESOLVED_ID === id ? buildSlidesModule() : undefined;
+    },
+
+    configureServer(server) {
+      const invalidate = (changedPath: string) => {
+        if (!changedPath.startsWith(SLIDES_DIR)) {
+          return;
+        }
+        const mod = server.moduleGraph.getModuleById(RESOLVED_ID);
+        if (mod) {
+          server.moduleGraph.invalidateModule(mod);
+        }
+        server.ws.send({ type: "full-reload" });
+      };
+
+      server.watcher.add(path.join(SLIDES_DIR, "*.html"));
+      server.watcher.on("add", invalidate);
+      server.watcher.on("change", invalidate);
+      server.watcher.on("unlink", invalidate);
+    },
+  };
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -8,6 +8,7 @@ import Home from "./pages/Home";
 import Introduction from "./pages/Introduction";
 import News from "./pages/News";
 import NewsDetail from "./pages/NewsDetail";
+import Slides from "./pages/Slides";
 
 function App() {
   return (
@@ -18,6 +19,7 @@ function App() {
         <Route path="/introduction" element={<Introduction />} />
         <Route path="/news" element={<News />} />
         <Route path="/news/:id" element={<NewsDetail />} />
+        <Route path="/slides" element={<Slides />} />
         <Route path="/contact" element={<Contact />} />
         <Route path="/contact/thanks" element={<ContactThanks />} />
       </Routes>

--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -54,6 +54,12 @@ export default function Header() {
               ニュース
             </Link>
             <Link
+              to="/slides"
+              className="text-gray-700 hover:text-gray-900 px-3 py-2 text-sm font-medium"
+            >
+              会社紹介資料
+            </Link>
+            <Link
               to="https://zenn.dev/p/techlead"
               className="text-gray-700 hover:text-gray-900 px-3 py-2 text-sm font-medium"
             >
@@ -117,6 +123,13 @@ export default function Header() {
               className="block text-gray-700 hover:text-gray-900 hover:bg-gray-50 px-3 py-2 rounded-md text-base font-medium"
             >
               ニュース
+            </Link>
+            <Link
+              to="/slides"
+              onClick={closeMobileMenu}
+              className="block text-gray-700 hover:text-gray-900 hover:bg-gray-50 px-3 py-2 rounded-md text-base font-medium"
+            >
+              会社紹介資料
             </Link>
             <Link
               to="https://zenn.dev/p/techlead"

--- a/web/src/data/slideParser.test.ts
+++ b/web/src/data/slideParser.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vite-plus/test";
+import type { Slide } from "../types";
+import { parseSlideEntry } from "./slideParser";
+
+describe("parseSlideEntry", () => {
+  it("extracts title, description and context from html head meta", () => {
+    const html = `<!doctype html>
+<html lang="ja">
+  <head>
+    <title>DX推進のご提案</title>
+    <meta name="description" content="現場の業務をどう変えるか" />
+    <meta name="slide-context" content="DX" />
+  </head>
+  <body></body>
+</html>`;
+
+    const expected: Slide = {
+      id: "dx",
+      title: "DX推進のご提案",
+      description: "現場の業務をどう変えるか",
+      context: "DX",
+    };
+    expect(parseSlideEntry("dx", html)).toEqual(expected);
+  });
+
+  it("falls back title to id when title tag is missing", () => {
+    const html = `<head>
+      <meta name="description" content="説明" />
+      <meta name="slide-context" content="DX" />
+    </head>`;
+
+    const expected: Slide = {
+      id: "sample",
+      title: "sample",
+      description: "説明",
+      context: "DX",
+    };
+    expect(parseSlideEntry("sample", html)).toEqual(expected);
+  });
+
+  it("defaults description to empty string when meta is missing", () => {
+    const html = `<head>
+      <title>タイトル</title>
+      <meta name="slide-context" content="DX" />
+    </head>`;
+
+    const expected: Slide = {
+      id: "sample",
+      title: "タイトル",
+      description: "",
+      context: "DX",
+    };
+    expect(parseSlideEntry("sample", html)).toEqual(expected);
+  });
+
+  it("defaults context to 'その他' when slide-context meta is missing", () => {
+    const html = `<head>
+      <title>タイトル</title>
+      <meta name="description" content="説明" />
+    </head>`;
+
+    const expected: Slide = {
+      id: "sample",
+      title: "タイトル",
+      description: "説明",
+      context: "その他",
+    };
+    expect(parseSlideEntry("sample", html)).toEqual(expected);
+  });
+
+  it("trims surrounding whitespace of the title", () => {
+    const html = `<head>
+      <title>
+        余白ありタイトル
+      </title>
+    </head>`;
+
+    const expected: Slide = {
+      id: "sample",
+      title: "余白ありタイトル",
+      description: "",
+      context: "その他",
+    };
+    expect(parseSlideEntry("sample", html)).toEqual(expected);
+  });
+});

--- a/web/src/data/slideParser.ts
+++ b/web/src/data/slideParser.ts
@@ -1,0 +1,32 @@
+import type { Slide } from "../types";
+
+/**
+ * スライドHTMLの <head> から <meta name="..."> の content を抽出する。
+ * name→content の順（一般的な記法）を対象とする。
+ */
+const extractMetaContent = (html: string, name: string): string | undefined => {
+  const pattern = new RegExp(
+    `<meta\\s+name=["']${name}["']\\s+content=["']([^"']*)["']`,
+    "i"
+  );
+  return html.match(pattern)?.[1];
+};
+
+/**
+ * スライドHTMLの <title> テキストを抽出する（前後空白は除去）。
+ */
+const extractTitle = (html: string): string | undefined => {
+  const match = html.match(/<title>([\s\S]*?)<\/title>/i);
+  return match?.[1].trim();
+};
+
+/**
+ * ファイル名(id)とスライドHTMLから一覧エントリ(Slide)を構築する。
+ * メタが無い場合: title→id / description→"" / context→"その他"。
+ */
+export const parseSlideEntry = (id: string, html: string): Slide => ({
+  id,
+  title: extractTitle(html) ?? id,
+  description: extractMetaContent(html, "description") ?? "",
+  context: extractMetaContent(html, "slide-context") ?? "その他",
+});

--- a/web/src/data/slides.ts
+++ b/web/src/data/slides.ts
@@ -1,7 +1,4 @@
-import type { Slide } from "../types";
-
-/**
- * 会社紹介資料（スライド）の一覧。
- * 実体は web/public/slides/{id}.html に配置する。
- */
-export const slides: Slide[] = [];
+// 会社紹介資料（スライド）の一覧。
+// 実体を web/public/slides/{id}.html に置くと vite-plugin-slides が
+// head メタを走査して自動でこの一覧に反映する。
+export { slides } from "virtual:slides";

--- a/web/src/data/slides.ts
+++ b/web/src/data/slides.ts
@@ -1,0 +1,7 @@
+import type { Slide } from "../types";
+
+/**
+ * 会社紹介資料（スライド）の一覧。
+ * 実体は web/public/slides/{id}.html に配置する。
+ */
+export const slides: Slide[] = [];

--- a/web/src/pages/Slides.test.tsx
+++ b/web/src/pages/Slides.test.tsx
@@ -1,0 +1,81 @@
+import { cleanup, render, screen, within } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, describe, expect, it } from "vite-plus/test";
+import type { Slide } from "../types";
+import Slides from "./Slides";
+
+function renderSlides(slides: Slide[]) {
+  return render(
+    <MemoryRouter initialEntries={["/slides"]}>
+      <Slides slides={slides} />
+    </MemoryRouter>
+  );
+}
+
+const dxSlide: Slide = {
+  id: "dx",
+  title: "DX推進のご提案",
+  description: "現場の業務をどう変えるか",
+  context: "DX",
+};
+
+const efficiencySlide: Slide = {
+  id: "efficiency",
+  title: "業務効率化のご提案",
+  description: "手作業を自動化して工数を削減",
+  context: "業務効率化",
+};
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("Slides", () => {
+  it("shows empty state message when there are no slides", () => {
+    renderSlides([]);
+
+    expect(
+      screen.getByText("現在、公開中の資料はありません。")
+    ).toBeInTheDocument();
+  });
+
+  it("shows the title of each slide", () => {
+    renderSlides([dxSlide, efficiencySlide]);
+
+    expect(screen.getByText("DX推進のご提案")).toBeInTheDocument();
+    expect(screen.getByText("業務効率化のご提案")).toBeInTheDocument();
+  });
+
+  it("links each slide card to its html file under /slides", () => {
+    renderSlides([dxSlide]);
+
+    const link = screen.getByRole("link", { name: /DX推進のご提案/ });
+    expect(link).toHaveAttribute("href", "/slides/dx.html");
+  });
+
+  it("groups slides by context and shows a heading per context", () => {
+    renderSlides([dxSlide, efficiencySlide]);
+
+    const dxHeading = screen.getByRole("heading", { name: "DX" });
+    const efficiencyHeading = screen.getByRole("heading", {
+      name: "業務効率化",
+    });
+
+    expect(dxHeading).toBeInTheDocument();
+    expect(efficiencyHeading).toBeInTheDocument();
+  });
+
+  it("shows slides with the same context under one heading group", () => {
+    const dxSlide2: Slide = {
+      id: "dx-detail",
+      title: "DX事例集",
+      description: "導入事例のまとめ",
+      context: "DX",
+    };
+    renderSlides([dxSlide, dxSlide2]);
+
+    const dxGroup = screen.getByRole("group", { name: "DX" });
+    expect(within(dxGroup).getByText("DX推進のご提案")).toBeInTheDocument();
+    expect(within(dxGroup).getByText("DX事例集")).toBeInTheDocument();
+  });
+});

--- a/web/src/pages/Slides.tsx
+++ b/web/src/pages/Slides.tsx
@@ -1,0 +1,75 @@
+import Card from "../components/ui/Card";
+import Section from "../components/ui/Section";
+import { slides as defaultSlides } from "../data/slides";
+import type { Slide } from "../types";
+
+interface SlidesProps {
+  slides?: Slide[];
+}
+
+/**
+ * 文脈（context）ごとにスライドをグルーピングする。
+ * 挿入順を保持するため Map を使う。
+ */
+const groupByContext = (slides: Slide[]): Map<string, Slide[]> => {
+  const groups = new Map<string, Slide[]>();
+  for (const slide of slides) {
+    const group = groups.get(slide.context) ?? [];
+    group.push(slide);
+    groups.set(slide.context, group);
+  }
+  return groups;
+};
+
+export default function Slides({ slides = defaultSlides }: SlidesProps) {
+  const groups = groupByContext(slides);
+
+  return (
+    <>
+      {/* ヒーローセクション */}
+      <Section background="gray">
+        <div className="text-center">
+          <h1 className="text-4xl md:text-5xl font-bold mb-4">会社紹介資料</h1>
+          <p className="text-lg md:text-xl text-gray-600">
+            業界・課題ごとの会社紹介資料をご覧いただけます
+          </p>
+        </div>
+      </Section>
+
+      {/* 資料一覧セクション */}
+      <Section background="white">
+        {0 === slides.length ? (
+          <p className="text-center text-gray-600">
+            現在、公開中の資料はありません。
+          </p>
+        ) : (
+          <div className="space-y-12">
+            {[...groups.entries()].map(([context, contextSlides]) => (
+              <section key={context} role="group" aria-label={context}>
+                <h2 className="text-2xl font-bold mb-6 text-gray-900">
+                  {context}
+                </h2>
+                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                  {contextSlides.map((slide) => (
+                    <a
+                      key={slide.id}
+                      href={`/slides/${slide.id}.html`}
+                      className="block"
+                    >
+                      <Card hover>
+                        <h3 className="text-xl font-bold mb-2 text-gray-900 hover:text-blue-600 transition-colors">
+                          {slide.title}
+                        </h3>
+                        <p className="text-gray-600">{slide.description}</p>
+                      </Card>
+                    </a>
+                  ))}
+                </div>
+              </section>
+            ))}
+          </div>
+        )}
+      </Section>
+    </>
+  );
+}

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -78,3 +78,10 @@ export interface NewsArticle {
   summary: string;
   content: string; // Markdown本文
 }
+
+export interface Slide {
+  id: string; // ファイル名。/slides/{id}.html として配信される
+  title: string;
+  description: string;
+  context: string; // "DX" などの文脈タグ。一覧のグルーピングに使う
+}

--- a/web/src/vite-env.d.ts
+++ b/web/src/vite-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="vite/client" />
+
+declare module "virtual:slides" {
+  export const slides: import("./types").Slide[];
+}

--- a/web/tsconfig.node.json
+++ b/web/tsconfig.node.json
@@ -23,5 +23,5 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["vite.config.ts"]
+  "include": ["vite.config.ts", "plugins", "scripts"]
 }

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -2,10 +2,11 @@ import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite-plus";
 import { vitePluginOgp } from "./plugins/vite-plugin-ogp";
+import { vitePluginSlides } from "./plugins/vite-plugin-slides";
 
 // https://vite.dev/config/
 export default defineConfig(() => ({
-  plugins: [tailwindcss(), react(), vitePluginOgp()],
+  plugins: [tailwindcss(), react(), vitePluginOgp(), vitePluginSlides()],
   build: {
     outDir: "dist",
   },


### PR DESCRIPTION
## 概要

いろんな業界・文脈向けの会社紹介スライド（Claude Design の単一HTML）を公式サイトから見られるようにする。`web/public/slides/*.html` を置くだけで一覧に自動反映される。

- URL: `https://techlead-it.com/slides/*.html`（実HTMLをそのまま配信）
- 一覧: `/#/slides`（context ごとにグルーピング表示）

構成変更（モノレポ/デプロイ/ドメイン）は不要。HashRouter のため実パス `/slides/*.html` は SPA ルーティングと衝突しない。

## 変更点

1. **一覧ページの枠組み** (`7950a12`)
   - `/#/slides` 一覧ページ・ヘッダー導線・`Slide` 型・空状態表示
2. **HTMLからの自動収集** (`f5163e2`)
   - `vite-plugin-slides` が `public/slides/*.html` の `<head>` メタ（title / description / `meta[name=slide-context]`）を走査し `virtual:slides` として供給
   - id=ファイル名、メタ欠落時は title→id / description→"" / context→"その他"
   - dev は変更監視で自動リロード

## 運用

`web/public/slides/dx.html` を置く（`<head>` に title/description/slide-context メタ）→ push → 一覧に自動反映、`techlead-it.com/slides/dx.html` で直接も開ける。並び順はファイル名昇順。

## 検証

- テスト 18/18 pass（slideParser 5 + Slides 5 + Contact 8、既存無傷）
- typecheck / lint / format 通過
- サンプルHTMLを置いて `pnpm build:web` → `virtual:slides` への焼き込みと `dist/slides/` への実HTML配置を実機確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)