### PR TITLE
🔧 chore: 必須チェックが paths フィルタでスキップされ PR がブロックされる問題を修正

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,9 +8,6 @@ on:
       - "**.md"
       - "LICENSE"
   pull_request:
-    paths-ignore:
-      - "**.md"
-      - "LICENSE"
 
 jobs:
   ci:

--- a/.github/workflows/pinact-check.yaml
+++ b/.github/workflows/pinact-check.yaml
@@ -3,8 +3,6 @@ name: Pinact Check
 on:
   workflow_dispatch:
   pull_request:
-    paths:
-      - ".github/workflows/**"
 
 jobs:
   pinact-check:


### PR DESCRIPTION
## Summary
- `pinact-check` が `pull_request.paths: [".github/workflows/**"]` のみで発火する設定になっており、ワークフローファイルを変更しない PR（例: dependabot の依存更新 PR）では実行されず、branch protection の必須ステータスチェックが `Expected` のままスタックしていた（例: #80）
- 同様に `ci` も `pull_request.paths-ignore: ["**.md", "LICENSE"]` を持ち、md/LICENSE のみ変更の PR で同じ問題が起きうるため合わせて修正
- 両ワークフローの `pull_request` トリガーからパスフィルタを削除し、全 PR で必須チェックが実行されるようにした（`push` (main) 側の `paths-ignore` はマージをブロックしないため維持）

## Test plan
- [ ] この PR 自体で `ci` と `pinact-check` の両方が SUCCESS になることを確認
- [ ] マージ後、#80 を rebase させて `pinact-check` が実行され `mergeStateStatus` が `BLOCKED` から解消されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)